### PR TITLE
feat: add support for CSV mime type in MediaInput allowedMimeTypes

### DIFF
--- a/.changeset/silly-chefs-worry.md
+++ b/.changeset/silly-chefs-worry.md
@@ -1,0 +1,5 @@
+---
+'@ethereal-nexus/core': minor
+---
+
+add support for CSV mime type in MediaInput allowedMimeTypes

--- a/lib/core/src/schema/media/media.ts
+++ b/lib/core/src/schema/media/media.ts
@@ -17,11 +17,12 @@ type ImageTypes = 'image/gif' | 'image/jpeg' | 'image/png' | 'image/tiff' | 'ima
 type VideoTypes = 'video/mp4' | 'video/webm' | 'video/ogg';
 type PDFTypes = 'application/pdf';
 type ZipTypes = 'application/zip' | 'application/x-zip-compressed' | 'application/x-zip' | 'application/x-compressed' | 'multipart/x-zip';
+type CSVType = 'text/csv';
 
 
 interface MediaInput extends BaseFieldInput {
   defaultValue?: string;
-  allowedMimeTypes?: ( PDFTypes | ZipTypes | ImageTypes | VideoTypes )[];
+  allowedMimeTypes?: ( PDFTypes | ZipTypes | ImageTypes | VideoTypes | CSVType)[];
 }
 
 export function media(input: MediaInput): MediaSchema {


### PR DESCRIPTION
[feat: add support for CSV mime type in MediaInput allowedMimeTypes](https://github.com/diconium/ethereal-nexus/commit/fe4f8fdc2ab4a286b94a0554d3eb03ca06b25b4b)