### PR TITLE
fix: remove versioning from file upload path in route.ts

### DIFF
--- a/.changeset/legal-walls-tickle.md
+++ b/.changeset/legal-walls-tickle.md
@@ -1,0 +1,5 @@
+---
+'@ethereal-nexus/dashboard': major
+---
+
+Removed the information about component and version from the asset url that is deployed to the bucket.

--- a/web/dashboard/src/app/api/v1/publish/route.ts
+++ b/web/dashboard/src/app/api/v1/publish/route.ts
@@ -83,7 +83,7 @@ export const POST = async (request) => {
       if (fileName.endsWith('.js') || fileName.endsWith('.css')) {
         const urlObject = await storage.uploadToStorage(
           content,
-          `${slug}/${version.version}`,
+          ``,
           fileName
         );
 


### PR DESCRIPTION
This pull request introduces a major change to the `@ethereal-nexus/dashboard` package by modifying how asset URLs are handled during deployment. The changes remove versioning and component information from asset URLs, simplifying the structure of deployed assets.

### Asset URL Simplification:

* [`.changeset/legal-walls-tickle.md`](diffhunk://#diff-2b02a215f005144c2fd93efc9b6888d83566368bfe0e15a89df460b5ce4f8691R1-R5): Documented the removal of component and version information from asset URLs in the `@ethereal-nexus/dashboard` package as a major change.
* [`web/dashboard/src/app/api/v1/publish/route.ts`](diffhunk://#diff-f548beb11c26484c0c9dbe198e28be5656cf0794bc0ae9b8e116b76be64930b2L86-R86): Updated the `POST` method to remove the inclusion of `slug` and `version.version` in asset URLs during storage uploads.