### PR TITLE
Feature/redirect

### DIFF
--- a/.changeset/polite-ads-heal.md
+++ b/.changeset/polite-ads-heal.md
@@ -1,0 +1,5 @@
+---
+'@ethereal-nexus/dashboard': minor
+---
+
+update redirect logic to use base URL from environment variables

--- a/web/dashboard/src/app/api/v1/cli-auth/route.ts
+++ b/web/dashboard/src/app/api/v1/cli-auth/route.ts
@@ -5,6 +5,7 @@ import { cookies } from 'next/headers';
 import { auth, signIn } from '@/auth';
 
 export async function GET(req: NextRequest) {
+  const baseUrl = process.env.NEXTAUTH_URL || req.nextUrl;
   const searchParams = req.nextUrl.searchParams;
   const callbackUrl = searchParams.get('callback');
 
@@ -25,5 +26,5 @@ export async function GET(req: NextRequest) {
     return await signIn();
   }
 
-  return NextResponse.redirect(new URL('/api/v1/cli-auth/callback', req.url));
+  return NextResponse.redirect(new URL('/api/v1/cli-auth/callback', baseUrl));
 }


### PR DESCRIPTION
This pull request updates the redirect logic in the `@ethereal-nexus/dashboard` package to use the base URL from environment variables, improving flexibility and configurability. The changes primarily affect the `GET` function in the `cli-auth` API route.

### Redirect Logic Updates:

* [`.changeset/polite-ads-heal.md`](diffhunk://#diff-cb7f4fd2cd5d1809d49bf88d2523fd3b020ef755f97bcca8072d466e022c0555R1-R5): Documented the minor update to redirect logic, specifying that the base URL now comes from environment variables.
* `web/dashboard/src/app/api/v1/cli-auth/route.ts`: 
  - Introduced `baseUrl` by using `process.env.NEXTAUTH_URL` or falling back to `req.nextUrl`.
  - Updated the redirect logic to use `baseUrl` instead of `req.url` for constructing the callback URL.