### PR TITLE
fix: Server asset js  with hash to generate multiple files since we have now all ssd assets on the same bucket.

### DIFF
--- a/.changeset/cold-gifts-peel.md
+++ b/.changeset/cold-gifts-peel.md
@@ -1,0 +1,5 @@
+---
+'@ethereal-nexus/vite-plugin-ethereal-nexus': minor
+---
+
+feat: implement hash-based file naming for prebuilt chunks

--- a/lib/vite-plugin/src/server/index.ts
+++ b/lib/vite-plugin/src/server/index.ts
@@ -6,6 +6,7 @@ import { simple } from 'acorn-walk';
 import path from 'node:path';
 import { getConfig } from '../config';
 import svgr from 'esbuild-plugin-svgr'
+import { createHash } from 'node:crypto';
 
 const ignoreCssPlugin: EsbuildPlugin  = {
   name: 'empty-css-imports',
@@ -76,9 +77,15 @@ export async function bundleSSR(code: string, id: string, ast: ProgramNode, name
     write: false, // Do not write to disk
   });
 
+  const hash = createHash('sha256')
+    .update(code)
+    .digest('hex')
+    .slice(0, 16);
+
+
   emitFile({
     type: 'prebuilt-chunk',
-    fileName: `.ethereal/${name}/server.js`,
+    fileName: `.ethereal/${name}/${hash}-server.js`,
     code: result.outputFiles[0].text
   });
 }


### PR DESCRIPTION
This pull request introduces a new feature to implement hash-based file naming for prebuilt chunks in the `@ethereal-nexus/vite-plugin-ethereal-nexus` package. It also updates the server-side bundling logic to incorporate this feature.

### New Feature: Hash-Based File Naming

* **Changeset file**: A minor version bump was defined for the `@ethereal-nexus/vite-plugin-ethereal-nexus` package to reflect the addition of the hash-based file naming feature. (`.changeset/cold-gifts-peel.md`, [.changeset/cold-gifts-peel.mdR1-R5](diffhunk://#diff-c02c67eacad327887e8fa8fd92f1efb6989fa832778050e32aeb770df6ce17daR1-R5))
* **Dependency update**: Added `createHash` from `node:crypto` to generate SHA-256 hashes for file names. (`lib/vite-plugin/src/server/index.ts`, [lib/vite-plugin/src/server/index.tsR9](diffhunk://#diff-02f8b70f40695ce3db38f6038a23719bc39fabb3f4a51a9bf2a2a616dde30167R9))

### Server-Side Bundling Logic Update

* **File name hashing**: Modified the `bundleSSR` function to compute a SHA-256 hash from the input code, truncate it to 16 characters, and use it in the file name for prebuilt chunks. This ensures unique and cache-friendly file names. (`lib/vite-plugin/src/server/index.ts`, [lib/vite-plugin/src/server/index.tsR80-R88](diffhunk://#diff-02f8b70f40695ce3db38f6038a23719bc39fabb3f4a51a9bf2a2a616dde30167R80-R88))