### PR TITLE
fix: update CheckBoxSchema to use boolean type for output

### DIFF
--- a/lib/core/src/schema/checkbox/checkbox.ts
+++ b/lib/core/src/schema/checkbox/checkbox.ts
@@ -1,6 +1,6 @@
 import { BaseFieldInput, type BaseSchema } from '../../types';
 
-export interface CheckBoxSchema<TOutput extends string = string> extends BaseSchema<TOutput> {
+export interface CheckBoxSchema<TOutput extends boolean = boolean> extends BaseSchema<TOutput> {
   /**
    * The schema type.
    */


### PR DESCRIPTION
This pull request updates the `CheckBoxSchema` interface in `checkbox.ts` to use `boolean` as its default output type instead of `string`. This change makes the schema's output type more accurate and better aligned with typical checkbox behavior in forms.

- Schema type correction:
  * Changed the default generic parameter for `CheckBoxSchema` from `string` to `boolean`, ensuring that checkbox values are typed as booleans rather than strings.