### PR TITLE
fix: update imports and improve build configuration for SpectrumPicke…

### DIFF
--- a/.changeset/lemon-terms-hope.md
+++ b/.changeset/lemon-terms-hope.md
@@ -1,0 +1,5 @@
+---
+'@ethereal-nexus/dialog-ui-spectrum': minor
+---
+
+update imports and improve build configuration for SpectrumPickerField

--- a/dialog-ui/dialog-ui-spectrum/README.md
+++ b/dialog-ui/dialog-ui-spectrum/README.md
@@ -31,6 +31,27 @@ This package requires React and React DOM as peer dependencies:
 npm install react react-dom
 ```
 
+### Importing Styles
+
+To use the components with their default styles, import the CSS file in your project:
+
+```tsx
+// In your main entry file (e.g., main.tsx, index.tsx, or App.tsx)
+import '@ethereal-nexus/dialog-ui-spectrum/styles.css';
+```
+
+Or in your CSS/SCSS file:
+
+```css
+@import '@ethereal-nexus/dialog-ui-spectrum/styles.css';
+```
+
+For vanilla HTML projects:
+
+```html
+<link rel="stylesheet" href="node_modules/@ethereal-nexus/dialog-ui-spectrum/dist/dialog-ui-spectrum.css">
+```
+
 ## Quick Start
 
 ```tsx

--- a/dialog-ui/dialog-ui-spectrum/package.json
+++ b/dialog-ui/dialog-ui-spectrum/package.json
@@ -7,6 +7,7 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
+    "./styles.css": "./dist/dialog-ui-spectrum.css",
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.js"
@@ -21,7 +22,7 @@
   ],
   "scripts": {
     "dev": "vite dev",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --watch",
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "storybook": "storybook dev -p 6006"
@@ -40,22 +41,22 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "@r2wc/react-to-web-component": "^2.0.4",
+    "@adobe/react-spectrum": "^3.45.0",
     "@ethereal-nexus/dialog-ui-core": "workspace:*",
-    "@adobe/react-spectrum": "^3.43.0",
-    "@spectrum-icons/workflow": "^4.2.23",
-    "@internationalized/date": "^3.5.4"
+    "@internationalized/date": "^3.5.4",
+    "@r2wc/react-to-web-component": "^2.0.4",
+    "@spectrum-icons/workflow": "^4.2.23"
   },
   "devDependencies": {
+    "@storybook/react-vite": "^9.1.10",
+    "@types/node": "^22.0.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.5",
-    "@types/node": "^22.0.0",
-    "@storybook/react-vite": "^9.1.10",
+    "@vitejs/plugin-react": "^4.6.0",
     "storybook": "^9.1.10",
     "typescript": "^5.4.2",
-    "vite": "^7.1.9",
+    "vite": "^7.1.11",
     "vite-plugin-dts": "^4.5.4",
-    "@vitejs/plugin-react": "^4.6.0",
     "vitest": "^3.2.4"
   }
 }

--- a/dialog-ui/dialog-ui-spectrum/src/components/SpectrumPickerField.tsx
+++ b/dialog-ui/dialog-ui-spectrum/src/components/SpectrumPickerField.tsx
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from "react";
 import {Picker, Item, ComboBox, TagGroup, Flex} from "@adobe/react-spectrum";
 import {FieldRendererProps} from '@ethereal-nexus/dialog-ui-core';
 import {handleIsolationCSS} from "./popoverUtils";
-import {useI18n} from '../providers';
+import {useI18n} from '@/providers';
 
 export interface SpectrumPickerFieldProps extends FieldRendererProps {
     field: any;

--- a/dialog-ui/dialog-ui-spectrum/src/index.ts
+++ b/dialog-ui/dialog-ui-spectrum/src/index.ts
@@ -1,6 +1,3 @@
 // UI Spectrum components and providers
 export * from './components';
 export * from './providers';
-
-// Web Components
-export { DialogRendererWebComponent } from './components/DialogRendererWebComponent';

--- a/dialog-ui/dialog-ui-spectrum/vite.config.ts
+++ b/dialog-ui/dialog-ui-spectrum/vite.config.ts
@@ -26,11 +26,11 @@ export default defineConfig(({mode}) => ({
                 index: resolve(__dirname, 'src/index.ts'),
             },
             name: 'EtherealNexusUISpectrum',
-            formats: ['es'], // Only build ESM format
+            formats: ['umd'],
             fileName: (format, entryName) => `${entryName}.esm.js`,
         },
-        sourcemap: true, // Enable source maps for debugging
-        minify: false, // Do not minify JS for easier debugging
+        sourcemap: false, // Enable source maps for debugging
+        minify: true, // Do not minify JS for easier debugging
         rollupOptions: {
             // Don't externalize anything - bundle everything for standalone web components
             external: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
   dialog-ui/dialog-ui-spectrum:
     dependencies:
       '@adobe/react-spectrum':
-        specifier: ^3.43.0
+        specifier: ^3.45.0
         version: 3.45.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ethereal-nexus/dialog-ui-core':
         specifier: workspace:*
@@ -175,7 +175,7 @@ importers:
     devDependencies:
       '@storybook/react-vite':
         specifier: ^9.1.10
-        version: 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+        version: 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@types/node':
         specifier: ^22.0.0
         version: 22.18.8
@@ -187,19 +187,19 @@ importers:
         version: 19.2.1(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+        version: 4.7.0(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       storybook:
         specifier: ^9.1.10
-        version: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+        version: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       typescript:
         specifier: ^5.4.2
         version: 5.6.2
       vite:
-        specifier: ^7.1.9
-        version: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+        specifier: ^7.1.11
+        version: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.18.8)(rollup@4.52.4)(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+        version: 4.5.4(@types/node@22.18.8)(rollup@4.52.4)(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.8)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@20.0.3)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
@@ -319,7 +319,7 @@ importers:
         version: 5.9.3
       vite-plugin-css-injected-by-js:
         specifier: ^3.5.2
-        version: 3.5.2(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+        version: 3.5.2(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
 
   lib/react:
     dependencies:
@@ -9581,6 +9581,46 @@ packages:
       yaml:
         optional: true
 
+  vite@7.1.12:
+    resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@7.1.9:
     resolution: {integrity: sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11329,7 +11369,7 @@ snapshots:
 
   '@internationalized/string@3.2.7':
     dependencies:
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
 
   '@ioredis/commands@1.4.0': {}
 
@@ -11524,12 +11564,12 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.19
       react-docgen-typescript: 2.4.0(typescript@5.6.2)
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     optionalDependencies:
       typescript: 5.6.2
 
@@ -12771,7 +12811,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.0)
       '@react-aria/utils': 3.31.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
@@ -12937,7 +12977,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.0)
       '@react-aria/utils': 3.31.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13160,7 +13200,7 @@ snapshots:
 
   '@react-aria/ssr@3.9.10(react@19.2.0)':
     dependencies:
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-aria/switch@3.7.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -13299,7 +13339,7 @@ snapshots:
       '@react-stately/flags': 3.1.2
       '@react-stately/utils': 3.10.8(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       clsx: 2.1.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -13320,7 +13360,7 @@ snapshots:
       '@react-aria/interactions': 3.25.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-aria/utils': 3.31.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13331,7 +13371,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -13353,7 +13393,7 @@ snapshots:
       '@react-types/actionbar': 3.1.19(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13376,7 +13416,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@spectrum-icons/workflow': 4.2.25(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13387,7 +13427,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/avatar': 3.0.19(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13399,7 +13439,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/badge': 3.1.21(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13418,7 +13458,7 @@ snapshots:
       '@react-types/breadcrumbs': 3.7.17(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13437,7 +13477,7 @@ snapshots:
       '@react-types/button': 3.14.1(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13448,7 +13488,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/buttongroup': 3.3.21(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13470,7 +13510,7 @@ snapshots:
       '@react-types/calendar': 3.8.0(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13488,7 +13528,7 @@ snapshots:
       '@react-types/checkbox': 3.10.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -13513,7 +13553,7 @@ snapshots:
       '@react-types/color': 3.1.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/textfield': 3.12.6(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -13545,7 +13585,7 @@ snapshots:
       '@react-types/combobox': 3.13.9(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13560,7 +13600,7 @@ snapshots:
       '@react-types/contextualhelp': 3.2.22(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/workflow': 4.2.25(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13586,7 +13626,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@spectrum-icons/workflow': 4.2.25(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13611,7 +13651,7 @@ snapshots:
       '@react-types/dialog': 3.5.22(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13621,7 +13661,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/divider': 3.3.21(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13631,7 +13671,7 @@ snapshots:
       '@react-spectrum/provider': 3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-stately/dnd': 3.7.1(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13642,7 +13682,7 @@ snapshots:
       '@react-spectrum/provider': 3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -13650,7 +13690,7 @@ snapshots:
   '@react-spectrum/filetrigger@3.0.18(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@react-spectrum/provider': 3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -13663,7 +13703,7 @@ snapshots:
       '@react-stately/form': 3.2.2(react@19.2.0)
       '@react-types/form': 3.7.16(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13685,7 +13725,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/illustratedmessage': 3.3.21(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13696,7 +13736,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/image': 3.5.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13710,7 +13750,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13738,7 +13778,7 @@ snapshots:
       '@react-spectrum/provider': 3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13749,7 +13789,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/layout': 3.3.27(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13763,7 +13803,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/link': 3.6.5(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13792,7 +13832,7 @@ snapshots:
       '@react-types/grid': 3.3.6(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -13817,7 +13857,7 @@ snapshots:
       '@react-types/listbox': 3.7.4(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13845,7 +13885,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@spectrum-icons/workflow': 4.2.25(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13857,7 +13897,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/meter': 3.4.13(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13880,7 +13920,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@spectrum-icons/workflow': 4.2.25(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13894,7 +13934,7 @@ snapshots:
       '@react-stately/overlays': 3.6.20(react@19.2.0)
       '@react-types/overlays': 3.9.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -13919,7 +13959,7 @@ snapshots:
       '@react-types/select': 3.11.0(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13931,7 +13971,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/progress': 3.5.16(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13943,7 +13983,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/provider': 3.8.13(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       clsx: 2.1.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -13960,7 +14000,7 @@ snapshots:
       '@react-stately/radio': 3.11.2(react@19.2.0)
       '@react-types/radio': 3.9.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13976,7 +14016,7 @@ snapshots:
       '@react-types/searchfield': 3.6.6(react@19.2.0)
       '@react-types/textfield': 3.12.6(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -13993,7 +14033,7 @@ snapshots:
       '@react-stately/slider': 3.7.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/slider': 3.8.2(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14004,7 +14044,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/statuslight': 3.3.21(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14018,7 +14058,7 @@ snapshots:
       '@react-stately/toggle': 3.9.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/switch': 3.5.15(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14050,7 +14090,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/table': 3.13.4(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14071,7 +14111,7 @@ snapshots:
       '@react-types/select': 3.11.0(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/tabs': 3.3.19(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14092,7 +14132,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.0)
       '@react-stately/list': 3.13.1(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14103,7 +14143,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/text': 3.3.21(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -14123,26 +14163,26 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/textfield': 3.12.6(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
   '@react-spectrum/theme-dark@3.5.22(react@19.2.0)':
     dependencies:
       '@react-types/provider': 3.8.13(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-spectrum/theme-default@3.5.22(react@19.2.0)':
     dependencies:
       '@react-types/provider': 3.8.13(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-spectrum/theme-light@3.4.22(react@19.2.0)':
     dependencies:
       '@react-types/provider': 3.8.13(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-spectrum/toast@3.1.4(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
@@ -14158,7 +14198,7 @@ snapshots:
       '@react-stately/toast': 3.1.2(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
@@ -14177,7 +14217,7 @@ snapshots:
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/tooltip': 3.4.21(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14193,7 +14233,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@spectrum-icons/ui': 3.6.20(@react-spectrum/provider@3.10.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-aria-components: 1.13.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
@@ -14216,7 +14256,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/view': 3.4.21(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14226,7 +14266,7 @@ snapshots:
       '@react-spectrum/utils': 3.12.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@react-types/shared': 3.32.1(react@19.2.0)
       '@react-types/well': 3.3.21(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
@@ -14257,7 +14297,7 @@ snapshots:
   '@react-stately/collections@3.12.8(react@19.2.0)':
     dependencies:
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-stately/color@3.9.2(react@19.2.0)':
@@ -14288,7 +14328,7 @@ snapshots:
   '@react-stately/data@3.14.1(react@19.2.0)':
     dependencies:
       '@react-types/shared': 3.32.1(react@19.2.0)
-      '@swc/helpers': 0.5.15
+      '@swc/helpers': 0.5.17
       react: 19.2.0
 
   '@react-stately/datepicker@3.15.2(react@19.2.0)':
@@ -14977,25 +15017,25 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/builder-vite@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+  '@storybook/builder-vite@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@storybook/csf-plugin': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       ts-dedent: 2.2.0
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
 
-  '@storybook/csf-plugin@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))':
+  '@storybook/csf-plugin@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))':
     dependencies:
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/react-dom-shim@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))':
+  '@storybook/react-dom-shim@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
 
   '@storybook/react-dom-shim@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))':
     dependencies:
@@ -15003,33 +15043,33 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
 
-  '@storybook/react-vite@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+  '@storybook/react-vite@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.4)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
-      '@storybook/builder-vite': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
-      '@storybook/react': 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)
+      '@storybook/builder-vite': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@storybook/react': 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)
       find-up: 7.0.0
       magic-string: 0.30.19
       react: 19.2.0
       react-docgen: 8.0.1
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.10
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       tsconfig-paths: 4.2.0
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)':
+  '@storybook/react@9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))(typescript@5.6.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))
+      '@storybook/react-dom-shim': 9.1.10(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
     optionalDependencies:
       typescript: 5.6.2
 
@@ -15594,7 +15634,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -15602,7 +15642,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15618,11 +15658,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.19
       sirv: 3.0.2
@@ -15662,13 +15702,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+
+  '@vitest/mocker@3.2.4(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
 
   '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))':
     dependencies:
@@ -17006,8 +17054,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.4(eslint@9.37.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.37.0(jiti@2.6.1))
@@ -17026,7 +17074,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -17038,22 +17086,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.37.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.37.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -17064,7 +17112,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.2.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.37.0(jiti@2.6.1)))(eslint@9.37.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20865,13 +20913,13 @@ snapshots:
 
   stdin-discarder@0.2.2: {}
 
-  storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
+  storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.10
@@ -21641,7 +21689,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21662,7 +21710,7 @@ snapshots:
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -21677,11 +21725,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
+  vite-plugin-css-injected-by-js@3.5.2(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
     dependencies:
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
 
-  vite-plugin-dts@4.5.4(@types/node@22.18.8)(rollup@4.52.4)(typescript@5.6.2)(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
+  vite-plugin-dts@4.5.4(@types/node@22.18.8)(rollup@4.52.4)(typescript@5.6.2)(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)):
     dependencies:
       '@microsoft/api-extractor': 7.53.1(@types/node@22.18.8)
       '@rollup/pluginutils': 5.3.0(rollup@4.52.4)
@@ -21694,7 +21742,7 @@ snapshots:
       magic-string: 0.30.19
       typescript: 5.6.2
     optionalDependencies:
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -21736,7 +21784,7 @@ snapshots:
       terser: 5.32.0
       yaml: 2.7.0
 
-  vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0):
+  vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -21746,6 +21794,23 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.18.8
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      sass: 1.93.2
+      terser: 5.32.0
+      yaml: 2.7.0
+
+  vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.4
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.9.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
@@ -21778,7 +21843,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -21796,13 +21861,13 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
       vite-node: 3.2.4(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.18.8
-      '@vitest/browser': 3.2.4(vite@7.1.9(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(vite@7.1.12(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))(vitest@3.2.4)
       jsdom: 20.0.3
     transitivePeerDependencies:
       - jiti
@@ -21822,7 +21887,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -21840,7 +21905,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.9(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
+      vite: 7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
       vite-node: 3.2.4(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.93.2)(terser@5.32.0)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
This pull request improves the build configuration and documentation for the `@ethereal-nexus/dialog-ui-spectrum` package, focusing on easier style imports, updated dependencies, and refined build outputs. It also includes minor import path cleanup and dependency version bumps for better compatibility and maintainability.

**Build and Packaging Improvements**
* Updated the Vite build configuration to output UMD format, enable minification, and disable source maps for production builds in `vite.config.ts`.
* Added an explicit export for the CSS file in `package.json` to allow consumers to import styles directly.
* Changed the build script to use `tsc && vite build --watch` for better development workflow.

**Documentation Updates**
* Added clear instructions in `README.md` for importing package styles in React, CSS/SCSS, and vanilla HTML projects.

**Dependency and Import Path Updates**
* Upgraded `@adobe/react-spectrum` and related dependencies to newer versions in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-d77b903a02584d21d2f652bde676099a674fb015146e4acd89082d5b9518f80bL43-L58) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL155-R155)
* Cleaned up import paths in `SpectrumPickerField.tsx` for consistency.

**Other Minor Changes**
* Removed unused web component export from `src/index.ts`.
* Updated `.changeset` to document the minor release and its improvements.…rField